### PR TITLE
Use a release build, compile wasm-ld, and don't build tools

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,10 @@ set -e
 emcmake cmake \
     -Wno-dev \
     -DLLVM_TARGETS_TO_BUILD=WebAssembly \
+    -DLLVM_BUILD_TOOLS=OFF \
+    -DLLVM_ENABLE_PROJECTS=lld \
     -DCMAKE_CXX_FLAGS="-sERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-unused-command-line-argument" \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Release \
     -GNinja \
     -S llvm-project/llvm \
     -B build-emscripten


### PR DESCRIPTION
Debug builds take up enormous amounts of memory when linking due to the generation of DWARF information. We might also need wasm-ld to link object files together. Lastly, we should try not to build unnecessary tools and binaries, so we disable building tools as a first step in that direction.